### PR TITLE
Fix local db creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ A web application to track and manage maintenance for your mountain bikes. Organ
 4. Seed the database:
 
    ```bash
-   npm run seed
+   npm run seeddb
    ```
 
 5. Start the server:

--- a/README.md
+++ b/README.md
@@ -65,9 +65,9 @@ A web application to track and manage maintenance for your mountain bikes. Organ
    npm run initdb
    ```
 
-  > Only use `rundb` the first use. Use `startdb` afterwards. Using `rundb`
-  > after the initial use will remove the original docker container and create a
-  > new one.
+    > Only use `rundb` the first use. Use `startdb` afterwards. Using `rundb` after
+    > the initial use will remove the original docker container and create a new
+    > one.
 
 4. Seed the database:
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ A web application to track and manage maintenance for your mountain bikes. Organ
    npm run initdb
    ```
 
+    `rundb` creates a postgres docker container that uses port 5433 (instead of
+    5432, which is the default for postgres) to avoid conflicts with local
+    postgres services. If port 5433 is already in use, choose a new port and
+    update the values in the `initdb` script in `package.json` and in the `db`
+    variable in `db/model.js`.
+
     > Only use `rundb` the first use. Use `startdb` afterwards. Using `rundb` after
     > the initial use will remove the original docker container and create a new
     > one.

--- a/README.md
+++ b/README.md
@@ -61,9 +61,13 @@ A web application to track and manage maintenance for your mountain bikes. Organ
 3. Start & Initialize the database:
 
    ```bash
-   npm run startdb
+   npm run rundb
    npm run initdb
    ```
+
+  > Only use `rundb` the first use. Use `startdb` afterwards. Using `rundb`
+  > after the initial use will remove the original docker container and create a
+  > new one.
 
 4. Seed the database:
 

--- a/db/db.js
+++ b/db/db.js
@@ -5,6 +5,7 @@ const connectToDB = async (dbURI) => {
 
   const sequelize = new Sequelize(dbURI, {
     logging: console.log,
+    username: 'postgres',
     dialect: 'postgres',
     define: {
       timestamps: false,

--- a/db/model.js
+++ b/db/model.js
@@ -3,7 +3,7 @@ import connectToDB from "./db.js";
 import url from 'url';
 import util from 'util';
 
-export const db = await connectToDB('postgresql://postgres:admin@localhost:5432/mtbmt');
+export const db = await connectToDB('postgresql://postgres:admin@localhost:5433/mtbmt');
 
 class User extends Model {
   [util.inspect.custom]() {

--- a/package.json
+++ b/package.json
@@ -8,11 +8,11 @@
     "build": "vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "rundb": "docker rm -f mtb-psql 2>/dev/null; docker run --name mtb-psql -e POSTGRES_PASSWORD=admin -d -p 5432:5432 postgres",
+    "rundb": "docker rm -f -v mtb-psql 2>/dev/null; docker run --name mtb-psql -e POSTGRES_PASSWORD=admin -d -p 5432:5432 postgres",
     "startdb": "docker start mtb-psql",
     "initdb": "PGPASSWORD=admin dropdb --user postgres --host localhost --port 5432 --if-exists mtbmt && PGPASSWORD=admin createdb --user postgres --host localhost --port 5432 mtbmt",
     "stopdb": "docker stop mtb-psql",
-    "rmdb": "docker rm mtb-psql",
+    "rmdb": "docker rm -v mtb-psql",
     "seed": "node db/seed.js"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "startdb": "docker run --name mtb-psql -e POSTGRES_PASSWORD=admin -d -p 5432:5432 postgres",
+    "startdb": "docker rm -f mtb-psql 2>/dev/null; docker run --name mtb-psql -e POSTGRES_PASSWORD=admin -d -p 5432:5432 postgres",
     "initdb": "dropdb --user postgres --password --host localhost --port 5432 --if-exists mtbmt && createdb --user postgres --password --host localhost --port 5432 mtbmt",
     "stopdb": "docker stop mtb-psql",
     "rmdb": "docker rm mtb-psql",

--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
     "build": "vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "initdb": "dropdb --user postgres --password --host localhost --port 5432 --if-exists mtbmt && createdb --user postgres --password --host localhost --port 5432 mtbmt",
     "rundb": "docker rm -f mtb-psql 2>/dev/null; docker run --name mtb-psql -e POSTGRES_PASSWORD=admin -d -p 5432:5432 postgres",
     "startdb": "docker start mtb-psql",
+    "initdb": "PGPASSWORD=admin dropdb --user postgres --host localhost --port 5432 --if-exists mtbmt && PGPASSWORD=admin createdb --user postgres --host localhost --port 5432 mtbmt",
     "stopdb": "docker stop mtb-psql",
     "rmdb": "docker rm mtb-psql",
     "seed": "node db/seed.js"

--- a/package.json
+++ b/package.json
@@ -8,8 +8,9 @@
     "build": "vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "startdb": "docker rm -f mtb-psql 2>/dev/null; docker run --name mtb-psql -e POSTGRES_PASSWORD=admin -d -p 5432:5432 postgres",
     "initdb": "dropdb --user postgres --password --host localhost --port 5432 --if-exists mtbmt && createdb --user postgres --password --host localhost --port 5432 mtbmt",
+    "rundb": "docker rm -f mtb-psql 2>/dev/null; docker run --name mtb-psql -e POSTGRES_PASSWORD=admin -d -p 5432:5432 postgres",
+    "startdb": "docker start mtb-psql",
     "stopdb": "docker stop mtb-psql",
     "rmdb": "docker rm mtb-psql",
     "seed": "node db/seed.js"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "rundb": "docker rm -f -v mtb-psql 2>/dev/null; docker run --name mtb-psql -e POSTGRES_PASSWORD=admin -d -p 5432:5432 postgres",
+    "rundb": "docker rm -f -v mtb-psql 2>/dev/null; docker run --name mtb-psql -e POSTGRES_PASSWORD=admin -d -p 5432:5432 postgres:14",
     "startdb": "docker start mtb-psql",
     "initdb": "PGPASSWORD=admin dropdb --user postgres --host localhost --port 5432 --if-exists mtbmt && PGPASSWORD=admin createdb --user postgres --host localhost --port 5432 mtbmt",
     "stopdb": "docker stop mtb-psql",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview",
     "rundb": "docker rm -f -v mtb-psql 2>/dev/null; docker run --name mtb-psql -e POSTGRES_PASSWORD=admin -d -p 5432:5432 postgres:14",
     "startdb": "docker start mtb-psql",
-    "initdb": "PGPASSWORD=admin dropdb --user postgres --host localhost --port 5432 --if-exists mtbmt && PGPASSWORD=admin createdb --user postgres --host localhost --port 5432 mtbmt",
+    "initdb": "PGPASSWORD=admin dropdb --username postgres --host localhost --port 5433 --if-exists mtbmt && PGPASSWORD=admin createdb --username postgres --host localhost --port 5433 mtbmt",
     "stopdb": "docker stop mtb-psql",
     "rmdb": "docker rm -v mtb-psql",
     "seeddb": "node db/seed.js"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "rundb": "docker rm -f -v mtb-psql 2>/dev/null; docker run --name mtb-psql -e POSTGRES_PASSWORD=admin -d -p 5432:5432 postgres:14",
+    "rundb": "docker rm -f -v mtb-psql 2>/dev/null; docker run --name mtb-psql -e POSTGRES_PASSWORD=admin -d -p 5433:5432 postgres:14",
     "startdb": "docker start mtb-psql",
     "initdb": "PGPASSWORD=admin dropdb --username postgres --host localhost --port 5433 --if-exists mtbmt && PGPASSWORD=admin createdb --username postgres --host localhost --port 5433 mtbmt",
     "stopdb": "docker stop mtb-psql",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "initdb": "PGPASSWORD=admin dropdb --user postgres --host localhost --port 5432 --if-exists mtbmt && PGPASSWORD=admin createdb --user postgres --host localhost --port 5432 mtbmt",
     "stopdb": "docker stop mtb-psql",
     "rmdb": "docker rm -v mtb-psql",
-    "seed": "node db/seed.js"
+    "seeddb": "node db/seed.js"
   },
   "dependencies": {
     "@reduxjs/toolkit": "^2.2.7",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "rundb": "docker rm -f -v mtb-psql 2>/dev/null; docker run --name mtb-psql -e POSTGRES_PASSWORD=admin -d -p 5433:5432 postgres:14",
+    "rundb": "docker rm -f -v mtb-psql 2>/dev/null; docker run --name mtb-psql -e POSTGRES_PASSWORD=admin -d -p 5433:5432 postgres:14; until pg_isready -h localhost -p 5433; do sleep 1; done",
     "startdb": "docker start mtb-psql",
     "initdb": "PGPASSWORD=admin dropdb --username postgres --host localhost --port 5433 --if-exists mtbmt && PGPASSWORD=admin createdb --username postgres --host localhost --port 5433 mtbmt",
     "stopdb": "docker stop mtb-psql",


### PR DESCRIPTION
This PR fixes issues when trying to startup a local db within a docker container. 

Changes include:
- Postgres Docker container creation:
  - changed `startdb` script to `rundb`
  - update `rundb` to remove existing docker container if exists (and remove associated volume)
  - pinned version 14 of Postgres
  - added `startdb` script (uses `docker start` instead of `docker run`)
  - changed docker port from 5432 to 5433 (to avoid conflicts with existing postgres services)
  - add `pg_isready` check to `rundb`
- Database creation and removal:
  - remove `--password` flag and pass `PGPASSWORD` env variable in `initdb`
  - update script names and instructions in README
  - update `rmdb` to remove associated docker volumes
- Sequelize:
  - update port in dbURI to 5433
  - add `username` to sequelize options object

The naming of the scripts was updated to be more inline with the docker commands being run within. The script used to create the docker container (`rundb`) attempts to remove an existing container if it exists, and a new script was created to start the container (`startdb`) for when the container has already been created. A new port was chosen (5433) in order to prevent conflicts with the default postgres port if any local postgres services are running. The version of postgres was pinned to v14 as there were issues using v15 used by the postgres docker image.